### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,7 @@ jobs:
           node-version: "18"
           
       - name: Install dependencies
-        run: npm install
-        
-      - name: Install validators
-        run: |
-          npm install -g htmlhint stylelint eslint
-          npm install -g stylelint-config-standard
+        run: npm ci
           
-      - name: Validate HTML
-        run: htmlhint src/**/*.html
-        
-      - name: Validate CSS
-        run: stylelint "src/**/*.css"
-        
-      - name: Validate JavaScript
-        run: eslint "src/**/*.js" --fix
+      - name: Lint project
+        run: npm run lint

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "live-server": "^1.2.2",
     "postcss": "^8.4.24",
     "postcss-cli": "^10.1.0",
-    "stylelint": "^15.6.2"
+    "stylelint": "^15.11.0",
+    "stylelint-config-standard": "^34.0.0"
   },
   "type": "module"
 }


### PR DESCRIPTION
## Summary
- add `stylelint-config-standard` and update `stylelint`
- simplify CI workflow to just run `npm run lint`

## Testing
- `npm run lint` *(fails: Expected empty line before rule, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684ed09712f4832ba8996f4d99c988ac